### PR TITLE
add output and standard answer in test to watch the output clearly

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -96,7 +96,11 @@ func judge(sampleID, command string) error {
 		state = color.New(color.FgRed).Sprintf("Failed #%v", sampleID)
 		dmp := diffmatchpatch.New()
 		d := dmp.DiffMain(out, ans, true)
-		diff = dmp.DiffPrettyText(d) + "\n"
+		diff += color.New(color.FgBlue).Sprintf("Your Answer:\n")
+		diff += color.New(color.FgBlue).Sprintf(dmp.DiffText1(d) + "\n")
+		diff += color.New(color.FgGreen).Sprintf("Answer:\n")
+		diff += color.New(color.FgGreen).Sprintf(dmp.DiffText2(d) + "\n")
+		diff += dmp.DiffPrettyText(d) + "\n"
 	}
 	ansi.Printf("%v .... %.3fs\n%v", state, dt.Seconds(), diff)
 	return nil


### PR DESCRIPTION
When we are solving a special judge problem, we need to watch our output, so add the output and standard answer.