### PR TITLE
Support proxy setting in config

### DIFF
--- a/cf.go
+++ b/cf.go
@@ -12,7 +12,7 @@ import (
 	docopt "github.com/docopt/docopt-go"
 )
 
-const version = "v0.8.2"
+const version = "v0.8.3"
 
 func main() {
 	usage := `Codeforces Tool $%version%$ (cf). https://github.com/xalanq/cf-tool

--- a/client/login.go
+++ b/client/login.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"regexp"
 
@@ -49,7 +48,7 @@ func (c *Client) Login(username, password string) (err error) {
 	jar, _ := cookiejar.New(nil)
 	color.Cyan("Login %v...\n", username)
 
-	c.client = &http.Client{Jar: jar}
+	c.client.Jar = jar
 
 	resp, err := c.client.Get(c.Host + "/enter")
 	if err != nil {

--- a/client/parse.go
+++ b/client/parse.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"html"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -45,8 +44,7 @@ func findSample(body []byte) (input [][]byte, output [][]byte, err error) {
 
 // ParseProblem parse problem to path
 func (c *Client) ParseProblem(URL, path string) (samples int, err error) {
-	client := &http.Client{Jar: c.Jar.Copy()}
-	resp, err := client.Get(URL)
+	resp, err := c.client.Get(URL)
 	if err != nil {
 		return
 	}

--- a/client/pull.go
+++ b/client/pull.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -52,8 +51,7 @@ func (c *Client) PullCode(contestID, submissionID, path, ext string, rename bool
 	}
 
 	URL := ToGym(fmt.Sprintf(c.Host+"/contest/%v/submission/%v", contestID, submissionID), contestID)
-	client := &http.Client{Jar: c.Jar.Copy()}
-	resp, err := client.Get(URL)
+	resp, err := c.client.Get(URL)
 	if err != nil {
 		return
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,7 +17,8 @@ func Config(args map[string]interface{}) error {
 	ansi.Println(`3) set default template`)
 	ansi.Println(`4) run "cf gen" after "cf parse"`)
 	ansi.Println(`5) set host domain`)
-	index := util.ChooseIndex(6)
+	ansi.Println(`6) set proxy`)
+	index := util.ChooseIndex(7)
 	if index == 0 {
 		return config.New(config.ConfigPath).Login(config.SessionPath)
 	} else if index == 1 {
@@ -30,6 +31,8 @@ func Config(args map[string]interface{}) error {
 		return config.New(config.ConfigPath).SetGenAfterParse()
 	} else if index == 5 {
 		return client.New(config.SessionPath).SetHost()
+	} else if index == 6 {
+		return client.New(config.SessionPath).SetProxy()
 	}
 	return nil
 }


### PR DESCRIPTION
As mentioned in #55, proxy setting in config now supported. User can set http/https/socks5 proxy in an additional config selection. Due to safety concerns, proxy with username and password is not supported.
A minor version updating is also conducted because of the new feature.