### PR TITLE
Added debugging before script

### DIFF
--- a/cf.go
+++ b/cf.go
@@ -33,7 +33,7 @@ Usage:
   cf list [<specifier>...]
   cf parse [<specifier>...]
   cf gen [<alias>]
-  cf test [<file>]
+  cf test [-d] [<file>]
   cf watch [all] [<specifier>...]
   cf open [<specifier>...]
   cf stand [<specifier>...]
@@ -48,6 +48,7 @@ Options:
   --version            Show version.
   -f <file>, --file <file>, <file>
                        Path to file. E.g. "a.cpp", "./temp/a.cpp"
+  -d --debug           Run with debugging before script.
   <specifier>          Any useful text. E.g.
                        "https://codeforces.com/contest/100",
                        "https://codeforces.com/contest/180/problem/A",
@@ -85,6 +86,7 @@ Examples:
                        test all samples. If you want to add a new testcase,
                        create two files "inK.txt" and "ansK.txt" where K is
                        a string with 0~9.
+  cf test -d           Run with debugging before script
   cf watch             Watch the first 10 submissions of current contest.
   cf watch all         Watch all submissions of current contest.
   cf open 1136a        Use default web browser to open the page of contest

--- a/cmd/args.go
+++ b/cmd/args.go
@@ -19,6 +19,7 @@ type ParsedArgs struct {
 	Alias     string   `docopt:"<alias>"`
 	Accepted  bool     `docopt:"ac"`
 	All       bool     `docopt:"all"`
+	Debug     bool     `docopt:"--debug"`
 	Handle    string   `docopt:"<handle>"`
 	Version   string   `docopt:"{version}"`
 	Config    bool     `docopt:"config"`

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -188,7 +188,14 @@ func Test() (err error) {
 		return nil
 	}
 
-	if err = run(template.BeforeScript); err != nil {
+	beforeScript := template.BeforeScript
+	if Args.Debug  {
+		if template.DbgBeforeScript==""{
+			return errors.New("debugging_before_script is not set in ~/.cf/config")
+		}
+		beforeScript = template.DbgBeforeScript
+	}
+	if err = run(beforeScript); err != nil {
 		return
 	}
 	if s := filter(template.Script); len(s) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"bytes"
 	"path/filepath"
 
 	"github.com/fatih/color"
@@ -13,13 +13,14 @@ import (
 
 // CodeTemplate config parse code template
 type CodeTemplate struct {
-	Alias        string   `json:"alias"`
-	Lang         string   `json:"lang"`
-	Path         string   `json:"path"`
-	Suffix       []string `json:"suffix"`
-	BeforeScript string   `json:"before_script"`
-	Script       string   `json:"script"`
-	AfterScript  string   `json:"after_script"`
+	Alias           string   `json:"alias"`
+	Lang            string   `json:"lang"`
+	Path            string   `json:"path"`
+	Suffix          []string `json:"suffix"`
+	BeforeScript    string   `json:"before_script"`
+	DbgBeforeScript string   `json:"debugging_before_script"`
+	Script          string   `json:"script"`
+	AfterScript     string   `json:"after_script"`
 }
 
 // Config load and save configuration

--- a/config/template.go
+++ b/config/template.go
@@ -118,12 +118,15 @@ func (c *Config) AddTemplate() (err error) {
 		color.Red("Script can not be empty. Please input again: ")
 	}
 
+	color.Cyan(`Debugging before script (e.g.  "g++ $%full%$ -o $%file%$.exe -std=c++11 -Donline_judge"), empty is ok: `)
+	dbgBeforeScript := util.ScanlineTrim()
+
 	color.Cyan(`After script (e.g. "rm $%file%$.exe" or "cmd.exe /C del $%file%$.exe" in windows), empty is ok: `)
 	afterScript := util.ScanlineTrim()
 
 	c.Template = append(c.Template, CodeTemplate{
 		alias, lang, path, suffix,
-		beforeScript, script, afterScript,
+		beforeScript, dbgBeforeScript, script, afterScript,
 	})
 
 	if util.YesOrNo("Make it default (y/n)? ") {


### PR DESCRIPTION
Fixes https://github.com/xalanq/cf-tool/issues/96

```json
{
  "template": [
    {
      "alias": "cpp",
      "lang": "54",
      "path": "...",
      "suffix": [
        "cpp"
      ],
      "before_script": "g++ $%full%$ -o $%file%$.o -std=c++17",
      "debugging_before_script": "g++ $%full%$ -o $%file%$.o -std=c++17 -Dlocal_pc",
      "script": "./$%file%$.o",
      "after_script": ""
    }
  ],
 }
}
```